### PR TITLE
PHP-FPM

### DIFF
--- a/easy-wi_install.sh
+++ b/easy-wi_install.sh
@@ -771,8 +771,11 @@ if [ "$INSTALL" == "EW" -o "$INSTALL" == "WR" -o "$INSTALL" == "MY" ]; then
 
             makeDir /home/$MASTERUSER/fpm-pool.d/
 
-            sed -i "s/include=\/etc\/php5\/fpm\/pool.d\/\*.conf/include=\/home\/$MASTERUSER\/fpm-pool.d\/\*.conf/g" /etc/php5/fpm/php-fpm.conf
-            sed -i "s/include=\/etc\/php\/7.0\/fpm\/pool.d\/\*.conf/include=\/home\/$MASTERUSER\/fpm-pool.d\/\*.conf/g" /etc/php/7.0/fpm/php-fpm.conf
+	    if [ -f /etc/php5/fpm/php-fpm.conf ]; then
+            	sed -i "s/include=\/etc\/php5\/fpm\/pool.d\/\*.conf/include=\/home\/$MASTERUSER\/fpm-pool.d\/\*.conf/g" /etc/php5/fpm/php-fpm.conf
+	    elif [ -f /etc/php/7.0/fpm/php-fpm.conf ]; then
+            	sed -i "s/include=\/etc\/php\/7.0\/fpm\/pool.d\/\*.conf/include=\/home\/$MASTERUSER\/fpm-pool.d\/\*.conf/g" /etc/php/7.0/fpm/php-fpm.conf
+	    fi
 
         elif [ "$WEBSERVER" == "Apache" ]; then
             checkInstall apache2-mpm-itk


### PR DESCRIPTION
Abfrage ob Datei existiert um Fehler in der Ausgabe zu unterdrücken

#Debian 8, Ubuntu 14.10
# PHP Packet php*-xml und php*-mbstring in php-common enthalten