### PR TITLE
some fixes for mariadb and sshkey and messages/typos

### DIFF
--- a/easy-wi_install.sh
+++ b/easy-wi_install.sh
@@ -1219,6 +1219,9 @@ _EOF_
 	# FIX MariaDB Install (#107)
 	if [ "$MYSQL_VERSION" == "Linux" ]; then
 		MYSQL_VERSION=$(mysql -V | awk {'print $3'} | tr -d . | cut -c 1-2)
+	elif [ "$MYSQL_VERSION" == *"-MariaDB"]; then
+		# -> mysql  Ver 15.1 Distrib 10.5.18-MariaDB, for debian-linux-gnu (x86_64) using  EditLine wrapper into 10
+		MYSQL_VERSION=$(mysql -V | awk '{ print $5 }' | tr -d , | tr -d 'MariaDB' | awk -F\- '{ print $1 }' | cut -c 1-2)
 	fi
 
 	if [ "$OS" == "debian" ] || [ "$OS" == "ubuntu" ]; then
@@ -2321,11 +2324,15 @@ _EOF_
 		read -r MYSQL_ROOT_PASSWORD
 	fi
 
-	# FIX MariaDB Install (#107)
-	if [ "$MYSQL_VERSION" -le "80" ]; then
-    	mysql -u root -p"$MYSQL_ROOT_PASSWORD" -e "CREATE DATABASE IF NOT EXISTS easy_wi; CREATE USER IF NOT EXISTS 'easy_wi'@'localhost' IDENTIFIED BY '$DB_PASSWORD'; GRANT ALL PRIVILEGES ON easy_wi.* TO 'easy_wi'@'localhost' WITH GRANT OPTION; FLUSH PRIVILEGES;"
-	else
-		mysql -u root -p"$MYSQL_ROOT_PASSWORD" -e "CREATE DATABASE IF NOT EXISTS easy_wi; CREATE USER IF NOT EXISTS 'easy_wi'@'localhost' IDENTIFIED BY '$DB_PASSWORD'; GRANT ALL ON easy_wi.* TO 'easy_wi'@'localhost'; FLUSH PRIVILEGES;"
+# FIX MariaDB Install (#107)
+
+	if [ "$MYSQL_VERSION" == "Linux" ]; then
+		MYSQL_VERSION=$(mysql -V | awk {'print $3'} | tr -d . | cut -c 1-2)
+	elif [[ "$MYSQL_VERSION" == *"-MariaDB" ]]; then
+		# -> mysql  Ver 15.1 Distrib 10.5.18-MariaDB, for debian-linux-gnu (x86_64) using  EditLine wrapper into 10
+		MYSQL_VERSION=$(mysql -V | awk '{ print $5 }' | tr -d , | tr -d 'MariaDB' | awk -F\- '{ print $1 }' | cut -c 1-2)
+		# adds 0 at the end for further checks now MYSQL_VERSION is 100
+		MYSQL_VERSION+="0"
 	fi
 
 	cyanMessage " "

--- a/easy-wi_install.sh
+++ b/easy-wi_install.sh
@@ -366,7 +366,7 @@ elif [ -f /etc/os-release ]; then
 	fi
 fi
 
-INSTALLER_VERSION=3.2
+INSTALLER_VERSION=3.3
 PKILL=$(which pkill)
 USERADD=$(which useradd)
 USERMOD=$(which usermod)

--- a/easy-wi_install.sh
+++ b/easy-wi_install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # DEBUG MODE
-DEBUG="ON"
+DEBUG="OFF"
 
 #    Author:     Ulrich Block <support@easy-wi.com>,
 #                Alexander Doerwald <support@easy-wi.com>

--- a/easy-wi_install.sh
+++ b/easy-wi_install.sh
@@ -2324,8 +2324,7 @@ _EOF_
 		read -r MYSQL_ROOT_PASSWORD
 	fi
 
-# FIX MariaDB Install (#107)
-
+	# FIX MariaDB Install (#107)
 	if [ "$MYSQL_VERSION" == "Linux" ]; then
 		MYSQL_VERSION=$(mysql -V | awk {'print $3'} | tr -d . | cut -c 1-2)
 	elif [[ "$MYSQL_VERSION" == *"-MariaDB" ]]; then

--- a/easy-wi_install.sh
+++ b/easy-wi_install.sh
@@ -2863,7 +2863,8 @@ elif [ "$INSTALL" == "GS" ]; then
 		greenOneLineMessage "Keyfile Name: "
 		cyanMessage "$MASTERUSER"
 	else
-		yellowMessage "Don't forget to copy Keyfile into \"/home/easywi_web/keys/\""
+		yellowMessage "Don't forget to copy your private Keyfile id_rsa from /home/"$MASTERUSER"/ into \"/home/EASYWI_PANEL/htdocs/keys/\" as "$MASTERUSER""
+		yellowMessage "Don't forget to copy your public Keyfile id_rsa.pub from /home/"$MASTERUSER"/ into \"/home/EASYWI_PANEL/htdocs/keys/\" as "$MASTERUSER".pub"
 	fi
 	if [ "$OS" == "centos" ] && [ "$FIREWALL" == "Yes" ]; then
 		redMessage " "
@@ -2899,7 +2900,8 @@ elif [ "$INSTALL" == "VS" ]; then
 		greenOneLineMessage "Keyfile Name: "
 		cyanMessage "$MASTERUSER"
 	else
-		yellowMessage "Don't forget to copy Keyfile into \"/home/easywi_web/keys/\""
+		yellowMessage "Don't forget to copy your private Keyfile id_rsa from /home/"$MASTERUSER"/ into \"/home/EASYWI_PANEL/htdocs/keys/\" as "$MASTERUSER""
+		yellowMessage "Don't forget to copy your public Keyfile id_rsa.pub from /home/"$MASTERUSER"/ into \"/home/EASYWI_PANEL/htdocs/keys/\" as "$MASTERUSER".pub"
 	fi
 	greenMessage " "
 elif [ "$INSTALL" == "WR" ]; then
@@ -2920,7 +2922,7 @@ elif [ "$INSTALL" == "WR" ]; then
 		greenOneLineMessage "Keyfile Name: "
 		cyanMessage "$MASTERUSER"
 	else
-		yellowMessage "Don't forget to copy Keyfile into \"/home/easywi_web/htdocs/keys/\""
+		yellowMessage "Don't forget to copy and your Keyfiles id_rsa and id_rsa.pub from /home/"$MASTERUSER"/.ssh into \"/home/EASYWI_PANEL/htdocs/keys/\""
 	fi
 	greenMessage " "
 	if [ -n "$MYSQL_ROOT_PASSWORD" ]; then

--- a/easy-wi_install.sh
+++ b/easy-wi_install.sh
@@ -926,7 +926,15 @@ if [[ "$INSTALL" != "MY" ]]; then
 
 		cyanMessage " "
 		cyanMessage "It is recommended but not required to set a password"
-		su -c "ssh-keygen -t rsa" "$MASTERUSER"
+
+
+		#ssh-keygen creates not yet supported encrypted open ssh keys since version 7.8 -> https://www.openssh.com/txt/release-7.8
+		# support for encrypted open ssh keys comes with phpseclib v3
+		if [ $(ssh -V |& awk -F'[_.]' '{ print $2 "." $3+0 }') -lt "7.8"];then
+			su -c "ssh-keygen -t rsa" "$MASTERUSER"
+		else
+			su -c "ssh-keygen -m PEM" "$MASTERUSER"
+		fi
 
 		KEYNAME=$(find -maxdepth 1 -name "*.pub" | head -n 1)
 

--- a/easy-wi_install.sh
+++ b/easy-wi_install.sh
@@ -583,6 +583,7 @@ if [ "$OS" == "ubuntu" ] && [ "$OSVERSION" -lt "1604" ] || [ "$OS" == "debian" ]
 		doReboot "System is rebooting now for finish Upgrade!"
 	else
 		if [ "$OS" == "ubuntu" ]; then
+			redMessage "Run this command to manually update your OS: "
 			redMessage "Command: do-release-upgrade"
 			redMessage " "
 			errorAndQuit
@@ -982,9 +983,9 @@ fi
 if [ "$INSTALL" == "EW" ] || [ "$INSTALL" == "MY" ]; then
 	if [ "$INSTALL" == "EW" ]; then
 		cyanMessage " "
-		okAndSleep "Please note that Easy-Wi requires a MySQL or MariaDB installed and will install MySQL if no DB is installed"
+		okAndSleep "Please note that Easy-Wi requires a MySQL or MariaDB server to be installed, and will install MariaDB if no server is already installed"
 	fi
-	// -lt -> less than
+	# -lt -> less than
 	if [ "$OS" == "debian" ] && [ "$OSVERSION" -lt "110" ] || [ "$OS" == "ubuntu" ]; then
 		if [[ -z "$(ps fax | grep 'mysqld' | grep -v 'grep')" || -z "$(ps fax | grep 'mariadb' | grep -v 'grep')" ]]; then
 			cyanMessage " "
@@ -1073,12 +1074,12 @@ if [ "$INSTALL" == "EW" ] || [ "$INSTALL" == "MY" ]; then
 			for search_mariadb in "${MARIADB_FILE[@]}"; do
 				if [ -z "$(grep '/MariaDB/' "$search_mariadb" >/dev/null 2>&1)" ] && [ ! -f /etc/yum.repos.d/MariaDB.repo ]; then
 					echo "# MariaDB $MARIADB_VERSION CentOS repository list
-# http://downloads.mariadb.org/mariadb/repositories/
-[mariadb]
-name = MariaDB
-baseurl = "http://yum.mariadb.org/"$MARIADB_VERSION"/centos"$MARIADB_TMP_VERSION"-amd64"
-gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
-gpgcheck=1" >/etc/yum.repos.d/MariaDB.repo
+						# http://downloads.mariadb.org/mariadb/repositories/
+						[mariadb]
+						name = MariaDB
+						baseurl = "http://yum.mariadb.org/"$MARIADB_VERSION"/centos"$MARIADB_TMP_VERSION"-amd64"
+						gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
+						gpgcheck=1" >/etc/yum.repos.d/MariaDB.repo
 				fi
 			done
 			importKey https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
@@ -1094,12 +1095,12 @@ gpgcheck=1" >/etc/yum.repos.d/MariaDB.repo
 	fi
 
 	if [ "$SQL" == "MySQL" ]; then
-		cyanMessage " "
+		cyanMessage " Checking if MySQL is installed ..."
 		checkInstall mysql-server
 		checkInstall mysql-client
 		checkInstall mysql-common
 	elif [ "$SQL" == "MariaDB" ]; then
-		cyanMessage " "
+		cyanMessage " Checking if MariaDB is installed ..."
 		# FIX MariaDB Install (#96) && => ||
 		if [ "$OS" == "debian" ] || [ "$OS" == "ubuntu" ]; then
 			checkInstall mariadb-server
@@ -1147,11 +1148,11 @@ gpgcheck=1" >/etc/yum.repos.d/MariaDB.repo
 		fi
 
 		mysql --user=root --password="$MYSQL_ROOT_PASSWORD" <<_EOF_
-DELETE FROM mysql.user WHERE User='';
-DELETE FROM mysql.user WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1');
-DROP DATABASE IF EXISTS test;
-DELETE FROM mysql.db WHERE Db='test' OR Db='test\\_%';
-FLUSH PRIVILEGES;
+				DELETE FROM mysql.user WHERE User='';
+				DELETE FROM mysql.user WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1');
+				DROP DATABASE IF EXISTS test;
+				DELETE FROM mysql.db WHERE Db='test' OR Db='test\\_%';
+				FLUSH PRIVILEGES;
 _EOF_
 	else
 		cyanMessage " "

--- a/easy-wi_install.sh
+++ b/easy-wi_install.sh
@@ -1276,8 +1276,6 @@ if [ "$PHPINSTALL" == "Yes" ]; then
 		USE_PHP_VERSION='7.4'
 	elif ([ "$OS" == "debian" ] && [ "$OSVERSION" -ge "85" ]) || ([ "$OS" == "ubuntu" ] && [ "$OSVERSION" -lt "1610" ]); then
 		USE_PHP_VERSION='7.4'
-	elif [ "$OS" == "debian" ] && [ "$OSVERSION" -ge "110" ]; then
-		USE_PHP_VERSION='7.4'
 	elif [ "$OS" == "ubuntu" ] && [ "$OSVERSION" -ge "1610" ] && [ "$OSVERSION" -lt "1803" ]; then
 		USE_PHP_VERSION='7.4'
 	elif [ "$OS" == "ubuntu" ] && [ "$OSVERSION" -ge "1803" ]; then

--- a/easy-wi_install.sh
+++ b/easy-wi_install.sh
@@ -1061,7 +1061,7 @@ if [ "$INSTALL" == "EW" ] || [ "$INSTALL" == "MY" ]; then
 			fi
 
             # FIX MariaDB Install (#96)
-			if [ -z $(apt-cache search mariadb-server-$MARIADB_VERSION 2> /dev/null) ]; then
+			if [ -z "$(apt-cache search mariadb-server-"$MARIADB_VERSION" 2> /dev/null)" ]; then
 			    curl -LsSO https://downloads.mariadb.com/MariaDB/mariadb-keyring-2019.gpg
                 mv mariadb-keyring-2019.gpg /etc/apt/trusted.gpg.d/
 				add-apt-repository "deb https://downloads.mariadb.com/MariaDB/mariadb-$MARIADB_VERSION/repo/$OS $OSBRANCH main"
@@ -2323,7 +2323,7 @@ _EOF_
 
 	# FIX MariaDB Install (#107)
 	if [ "$MYSQL_VERSION" -le "80" ]; then
-    mysql -u root -p"$MYSQL_ROOT_PASSWORD" -e "CREATE DATABASE IF NOT EXISTS easy_wi; CREATE USER IF NOT EXISTS 'easy_wi'@'localhost' IDENTIFIED BY '$DB_PASSWORD'; GRANT ALL PRIVILEGES ON easy_wi.* TO 'easy_wi'@'localhost' WITH GRANT OPTION; FLUSH PRIVILEGES;"
+    	mysql -u root -p"$MYSQL_ROOT_PASSWORD" -e "CREATE DATABASE IF NOT EXISTS easy_wi; CREATE USER IF NOT EXISTS 'easy_wi'@'localhost' IDENTIFIED BY '$DB_PASSWORD'; GRANT ALL PRIVILEGES ON easy_wi.* TO 'easy_wi'@'localhost' WITH GRANT OPTION; FLUSH PRIVILEGES;"
 	else
 		mysql -u root -p"$MYSQL_ROOT_PASSWORD" -e "CREATE DATABASE IF NOT EXISTS easy_wi; CREATE USER IF NOT EXISTS 'easy_wi'@'localhost' IDENTIFIED BY '$DB_PASSWORD'; GRANT ALL ON easy_wi.* TO 'easy_wi'@'localhost'; FLUSH PRIVILEGES;"
 	fi

--- a/easy-wi_install.sh
+++ b/easy-wi_install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # DEBUG MODE
-DEBUG="OFF"
+DEBUG="ON"
 
 #    Author:     Ulrich Block <support@easy-wi.com>,
 #                Alexander Doerwald <support@easy-wi.com>
@@ -872,8 +872,8 @@ if [ "$INSTALL" == "VS" ]; then
 
 	okAndSleep "Detected latest server version as $VERSION with download URL $DOWNLOAD_URL"
 fi
-
-if [ "$INSTALL" != "MY" ]; then
+#evenntuell ändern
+if [[ "$INSTALL" != "MY" ]]; then
 	cyanMessage " "
 	cyanMessage "Please enter the name of the masteruser, which does not exist yet."
 	read MASTERUSER
@@ -985,8 +985,8 @@ if [ "$INSTALL" == "EW" ] || [ "$INSTALL" == "MY" ]; then
 		cyanMessage " "
 		okAndSleep "Please note that Easy-Wi requires a MySQL or MariaDB server to be installed, and will install MariaDB if no server is already installed"
 	fi
-	# -lt -> less than
-	if [ "$OS" == "debian" ] && [ "$OSVERSION" -lt "110" ] || [ "$OS" == "ubuntu" ]; then
+	# don't use mysql for debian >= 10
+	if [ "$OS" == "debian" ] && [ "$OSVERSION" -lt "100" ] || [ "$OS" == "ubuntu" ]; then
 		if [[ -z "$(ps fax | grep 'mysqld' | grep -v 'grep')" || -z "$(ps fax | grep 'mariadb' | grep -v 'grep')" ]]; then
 			cyanMessage " "
 			cyanMessage "Please select which database server to install."
@@ -1230,7 +1230,7 @@ _EOF_
 
 	RestartDatabase
 
-	if [[ -z "$(ps fax | grep 'mysqld' | grep -v 'grep')" || -z "$(ps fax | grep 'mariadb' | grep -v 'grep')" ]]; then
+	if [-z "$(ps fax | grep 'mysqld' | grep -v 'grep')" ] || [-z "$(ps fax | grep 'mariadb' | grep -v 'grep')" ]; then
 		cyanMessage " "
 		errorAndExit "Error: No SQL server running but required for Webpanel installation."
 	fi


### PR DESCRIPTION
I fixed some minor issues with MariaDB in Debian11, as well as a temporary the way ssh keys are generated for OpenSSH7.8 and up

> ssh-keygen creates not yet supported encrypted open ssh keys since version 7.8
support for encrypted open ssh keys comes with phpseclib v3 see https://github.com/easy-wi/developer/issues/1347

https://www.openssh.com/txt/release-7.8

Fixed:

> key file message https://github.com/easy-wi/installer/issues/108
> easy-wi_install.sh: line 2325: [: 10.3.38-MariaDB: integer expression expected

deleted:
> debian 11 check in php7.4 as it is already covered by the debian10 check

This file is tested against debian10 and 11 using only the installation with EasyWi Web!